### PR TITLE
Add missing semicolon

### DIFF
--- a/handlers/Main.cfc
+++ b/handlers/Main.cfc
@@ -1,1 +1,11 @@
-﻿component{	/**	* index	*/	function index( event, rc, prc ){		prc.welcomeMessage = "Welcome to ColdBox!"		event.setView( "Main/index" );	}}
+﻿component{
+
+	/**
+	* index
+	*/
+	function index( event, rc, prc ){
+		prc.welcomeMessage = "Welcome to ColdBox!";
+		event.setView( "Main/index" );
+	}
+
+}


### PR DESCRIPTION
`start cfengine=adobe@2016` threw an error with this small sample