### PR TITLE
Add workspace files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 settings.xml
 WEB-INF
+*.code-workspace
 
 # Engines + Database + CBFS + Secrets
 .env


### PR DESCRIPTION
VS Code workspace files contain personal IDE preferences. They should not be committed.